### PR TITLE
fix numpy deprecated byte manipulation methods

### DIFF
--- a/recording_examples/record_one_channel.py
+++ b/recording_examples/record_one_channel.py
@@ -27,8 +27,8 @@ frames = []
 for i in range(0, int(RESPEAKER_RATE / CHUNK * RECORD_SECONDS)):
     data = stream.read(CHUNK)
     # extract channel 0 data from 2 channels, if you want to extract channel 1, please change to [1::2]
-    a = np.fromstring(data,dtype=np.int16)[0::2]
-    frames.append(a.tostring())
+    a = np.frombuffer(data,dtype=np.int16)[0::2]
+    frames.append(a.tobytes())
 
 print("* done recording")
 


### PR DESCRIPTION
As discussed in #11 , I've updated the numpy deprecated methods `numpy.fromstring( )` and `ndarray.tostring( )`

Tested with a reTerminal and reSpeaker 2-mic hat.